### PR TITLE
Add support for f32 constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,12 @@ impl<T: Clone> From<f64> for Expression<T> {
     }
 }
 
+impl<T: Clone> From<f32> for Expression<T> {
+    fn from(v: f32) -> Expression<T> {
+        Expression::from_constant(v as f64)
+    }
+}
+
 impl<T: Clone> From<i32> for Expression<T> {
     fn from(v: i32) -> Expression<T> {
         Expression::from_constant(v as f64)


### PR DESCRIPTION
This PR adds support for f32 constants, similar to f64, i32, and u32 constants
