### PR TITLE
Add std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,15 @@ repository = "https://github.com/schell/casuarius"
 readme = "README.md"
 license = "MIT / Apache-2.0"
 keywords = ["constraint", "simplex", "user", "interface", "layout"]
+rust-version = "1.63"
+
+[features]
+default = ["std"]
+std = ["rustc-hash/std"]
+# FIXME: should be enabled only if std feature is disabled but cargo can not do that yet
+hashbrown = ["dep:hashbrown"]
 
 [dependencies]
-ordered-float = "^1.0"
-rustc-hash = "^1.1"
+ordered-float = "1.0"
+rustc-hash = { version = "1.1", default-features = false }
+hashbrown = { version = "0.14", default-features = false, optional = true }

--- a/src/derive_syntax.rs
+++ b/src/derive_syntax.rs
@@ -272,7 +272,7 @@ macro_rules! derive_syntax_for {
 
 #[cfg(test)]
 mod tests {
-    use crate::{self as casuarius, Solver, Constrainable};
+    use crate::{self as casuarius, Constrainable, Solver};
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     enum VariableX {

--- a/src/derive_syntax.rs
+++ b/src/derive_syntax.rs
@@ -9,49 +9,49 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::Add<f64> for $x {
+        impl core::ops::Add<f64> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: f64) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(self, 1.0)], v)
             }
         }
 
-        impl std::ops::Add<f32> for $x {
+        impl core::ops::Add<f32> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: f32) -> casuarius::Expression<$x> {
                 self.add(v as f64)
             }
         }
 
-        impl std::ops::Add<u32> for $x {
+        impl core::ops::Add<u32> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: u32) -> casuarius::Expression<$x> {
                 self.add(v as f64)
             }
         }
 
-        impl std::ops::Add<$x> for f64 {
+        impl core::ops::Add<$x> for f64 {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(v, 1.0)], self)
             }
         }
 
-        impl std::ops::Add<$x> for f32 {
+        impl core::ops::Add<$x> for f32 {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: $x) -> casuarius::Expression<$x> {
                 (self as f64).add(v)
             }
         }
 
-        impl std::ops::Add<$x> for u32 {
+        impl core::ops::Add<$x> for u32 {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: $x) -> casuarius::Expression<$x> {
                 (self as f64).add(v)
             }
         }
 
-        impl std::ops::Add<$x> for $x {
+        impl core::ops::Add<$x> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(
@@ -64,21 +64,21 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::Add<casuarius::Term<$x>> for $x {
+        impl core::ops::Add<casuarius::Term<$x>> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, t: casuarius::Term<$x>) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(self, 1.0), t], 0.0)
             }
         }
 
-        impl std::ops::Add<$x> for casuarius::Term<$x> {
+        impl core::ops::Add<$x> for casuarius::Term<$x> {
             type Output = casuarius::Expression<$x>;
             fn add(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![self, casuarius::Term::new(v, 1.0)], 0.0)
             }
         }
 
-        impl std::ops::Add<casuarius::Expression<$x>> for $x {
+        impl core::ops::Add<casuarius::Expression<$x>> for $x {
             type Output = casuarius::Expression<$x>;
             fn add(self, mut e: casuarius::Expression<$x>) -> casuarius::Expression<$x> {
                 e.terms.push(casuarius::Term::new(self, 1.0));
@@ -86,7 +86,7 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::Add<$x> for casuarius::Expression<$x> {
+        impl core::ops::Add<$x> for casuarius::Expression<$x> {
             type Output = casuarius::Expression<$x>;
             fn add(mut self, v: $x) -> casuarius::Expression<$x> {
                 self += v;
@@ -94,62 +94,62 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::AddAssign<$x> for casuarius::Expression<$x> {
+        impl core::ops::AddAssign<$x> for casuarius::Expression<$x> {
             fn add_assign(&mut self, v: $x) {
                 self.terms.push(casuarius::Term::new(v, 1.0));
             }
         }
 
-        impl std::ops::Neg for $x {
+        impl core::ops::Neg for $x {
             type Output = casuarius::Term<$x>;
             fn neg(self) -> casuarius::Term<$x> {
                 casuarius::Term::new(self, -1.0)
             }
         }
 
-        impl std::ops::Sub<f64> for $x {
+        impl core::ops::Sub<f64> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: f64) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(self, 1.0)], -v)
             }
         }
 
-        impl std::ops::Sub<f32> for $x {
+        impl core::ops::Sub<f32> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: f32) -> casuarius::Expression<$x> {
                 self.sub(v as f64)
             }
         }
 
-        impl std::ops::Sub<u32> for $x {
+        impl core::ops::Sub<u32> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: u32) -> casuarius::Expression<$x> {
                 self.sub(v as f64)
             }
         }
 
-        impl std::ops::Sub<$x> for f64 {
+        impl core::ops::Sub<$x> for f64 {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(v, -1.0)], self)
             }
         }
 
-        impl std::ops::Sub<$x> for f32 {
+        impl core::ops::Sub<$x> for f32 {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: $x) -> casuarius::Expression<$x> {
                 (self as f64).sub(v)
             }
         }
 
-        impl std::ops::Sub<$x> for u32 {
+        impl core::ops::Sub<$x> for u32 {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: $x) -> casuarius::Expression<$x> {
                 (self as f64).sub(v)
             }
         }
 
-        impl std::ops::Sub<$x> for $x {
+        impl core::ops::Sub<$x> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(
@@ -162,21 +162,21 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::Sub<casuarius::Term<$x>> for $x {
+        impl core::ops::Sub<casuarius::Term<$x>> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, t: casuarius::Term<$x>) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![casuarius::Term::new(self, 1.0), -t], 0.0)
             }
         }
 
-        impl std::ops::Sub<$x> for casuarius::Term<$x> {
+        impl core::ops::Sub<$x> for casuarius::Term<$x> {
             type Output = casuarius::Expression<$x>;
             fn sub(self, v: $x) -> casuarius::Expression<$x> {
                 casuarius::Expression::new(vec![self, casuarius::Term::new(v, -1.0)], 0.0)
             }
         }
 
-        impl std::ops::Sub<casuarius::Expression<$x>> for $x {
+        impl core::ops::Sub<casuarius::Expression<$x>> for $x {
             type Output = casuarius::Expression<$x>;
             fn sub(self, mut e: casuarius::Expression<$x>) -> casuarius::Expression<$x> {
                 e.negate();
@@ -185,7 +185,7 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::Sub<$x> for casuarius::Expression<$x> {
+        impl core::ops::Sub<$x> for casuarius::Expression<$x> {
             type Output = casuarius::Expression<$x>;
             fn sub(mut self, v: $x) -> casuarius::Expression<$x> {
                 self -= v;
@@ -193,48 +193,48 @@ macro_rules! derive_syntax_for {
             }
         }
 
-        impl std::ops::SubAssign<$x> for casuarius::Expression<$x> {
+        impl core::ops::SubAssign<$x> for casuarius::Expression<$x> {
             fn sub_assign(&mut self, v: $x) {
                 self.terms.push(casuarius::Term::new(v, -1.0));
             }
         }
 
-        impl std::ops::Mul<f64> for $x {
+        impl core::ops::Mul<f64> for $x {
             type Output = casuarius::Term<$x>;
             fn mul(self, v: f64) -> casuarius::Term<$x> {
                 casuarius::Term::new(self, v)
             }
         }
 
-        impl std::ops::Mul<f32> for $x {
+        impl core::ops::Mul<f32> for $x {
             type Output = casuarius::Term<$x>;
             fn mul(self, v: f32) -> casuarius::Term<$x> {
                 self.mul(v as f64)
             }
         }
 
-        impl std::ops::Mul<$x> for f64 {
+        impl core::ops::Mul<$x> for f64 {
             type Output = casuarius::Term<$x>;
             fn mul(self, v: $x) -> casuarius::Term<$x> {
                 casuarius::Term::new(v, self)
             }
         }
 
-        impl std::ops::Mul<$x> for f32 {
+        impl core::ops::Mul<$x> for f32 {
             type Output = casuarius::Term<$x>;
             fn mul(self, v: $x) -> casuarius::Term<$x> {
                 (self as f64).mul(v)
             }
         }
 
-        impl std::ops::Div<f64> for $x {
+        impl core::ops::Div<f64> for $x {
             type Output = casuarius::Term<$x>;
             fn div(self, v: f64) -> casuarius::Term<$x> {
                 casuarius::Term::new(self, 1.0 / v)
             }
         }
 
-        impl std::ops::Div<f32> for $x {
+        impl core::ops::Div<f32> for $x {
             type Output = casuarius::Term<$x>;
             fn div(self, v: f32) -> casuarius::Term<$x> {
                 self.div(v as f64)

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -1,0 +1,27 @@
+pub use self::imp::*;
+
+#[cfg(feature = "std")]
+mod imp {
+    pub use rustc_hash::{FxHashMap, FxHashSet};
+    pub use std::collections::hash_map::Entry;
+}
+
+#[cfg(not(feature = "std"))]
+mod imp {
+    use rustc_hash::FxHasher;
+
+    pub use hashbrown::hash_map::Entry;
+
+    pub type FxHashMap<K, V> = hashbrown::HashMap<K, V, FxBuildHasher>;
+    pub type FxHashSet<V> = hashbrown::HashSet<V, FxBuildHasher>;
+
+    #[derive(Copy, Clone, Default)]
+    pub struct FxBuildHasher;
+
+    impl core::hash::BuildHasher for FxBuildHasher {
+        type Hasher = FxHasher;
+        fn build_hasher(&self) -> FxHasher {
+            rustc_hash::FxHasher::default()
+        }
+    }
+}

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -42,7 +42,7 @@ where
 
 // Term
 
-impl<T> std::ops::Mul<f64> for Term<T> {
+impl<T> core::ops::Mul<f64> for Term<T> {
     type Output = Term<T>;
     fn mul(mut self, v: f64) -> Term<T> {
         self *= v;
@@ -50,26 +50,26 @@ impl<T> std::ops::Mul<f64> for Term<T> {
     }
 }
 
-impl<T> std::ops::MulAssign<f64> for Term<T> {
+impl<T> core::ops::MulAssign<f64> for Term<T> {
     fn mul_assign(&mut self, v: f64) {
         *(self.coefficient.as_mut()) *= v;
     }
 }
 
-impl<T> std::ops::Mul<f32> for Term<T> {
+impl<T> core::ops::Mul<f32> for Term<T> {
     type Output = Term<T>;
     fn mul(self, v: f32) -> Term<T> {
         self.mul(v as f64)
     }
 }
 
-impl<T> std::ops::MulAssign<f32> for Term<T> {
+impl<T> core::ops::MulAssign<f32> for Term<T> {
     fn mul_assign(&mut self, v: f32) {
         self.mul_assign(v as f64)
     }
 }
 
-impl<T> std::ops::Mul<Term<T>> for f64 {
+impl<T> core::ops::Mul<Term<T>> for f64 {
     type Output = Term<T>;
     fn mul(self, mut t: Term<T>) -> Term<T> {
         *(t.coefficient.as_mut()) *= self;
@@ -77,14 +77,14 @@ impl<T> std::ops::Mul<Term<T>> for f64 {
     }
 }
 
-impl<T> std::ops::Mul<Term<T>> for f32 {
+impl<T> core::ops::Mul<Term<T>> for f32 {
     type Output = Term<T>;
     fn mul(self, t: Term<T>) -> Term<T> {
         (self as f64).mul(t)
     }
 }
 
-impl<T> std::ops::Div<f64> for Term<T> {
+impl<T> core::ops::Div<f64> for Term<T> {
     type Output = Term<T>;
     fn div(mut self, v: f64) -> Term<T> {
         self /= v;
@@ -92,61 +92,61 @@ impl<T> std::ops::Div<f64> for Term<T> {
     }
 }
 
-impl<T> std::ops::DivAssign<f64> for Term<T> {
+impl<T> core::ops::DivAssign<f64> for Term<T> {
     fn div_assign(&mut self, v: f64) {
         *(self.coefficient.as_mut()) /= v;
     }
 }
 
-impl<T> std::ops::Div<f32> for Term<T> {
+impl<T> core::ops::Div<f32> for Term<T> {
     type Output = Term<T>;
     fn div(self, v: f32) -> Term<T> {
         self.div(v as f64)
     }
 }
 
-impl<T> std::ops::DivAssign<f32> for Term<T> {
+impl<T> core::ops::DivAssign<f32> for Term<T> {
     fn div_assign(&mut self, v: f32) {
         self.div_assign(v as f64)
     }
 }
 
-impl<T: Clone> std::ops::Add<f64> for Term<T> {
+impl<T: Clone> core::ops::Add<f64> for Term<T> {
     type Output = Expression<T>;
     fn add(self, v: f64) -> Expression<T> {
         Expression::new(vec![self], v)
     }
 }
 
-impl<T: Clone> std::ops::Add<f32> for Term<T> {
+impl<T: Clone> core::ops::Add<f32> for Term<T> {
     type Output = Expression<T>;
     fn add(self, v: f32) -> Expression<T> {
         self.add(v as f64)
     }
 }
 
-impl<T: Clone> std::ops::Add<Term<T>> for f64 {
+impl<T: Clone> core::ops::Add<Term<T>> for f64 {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![t], self)
     }
 }
 
-impl<T: Clone> std::ops::Add<Term<T>> for f32 {
+impl<T: Clone> core::ops::Add<Term<T>> for f32 {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         (self as f64).add(t)
     }
 }
 
-impl<T: Clone> std::ops::Add<Term<T>> for Term<T> {
+impl<T: Clone> core::ops::Add<Term<T>> for Term<T> {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![self, t], 0.0)
     }
 }
 
-impl<T> std::ops::Add<Expression<T>> for Term<T> {
+impl<T> core::ops::Add<Expression<T>> for Term<T> {
     type Output = Expression<T>;
     fn add(self, mut e: Expression<T>) -> Expression<T> {
         e.terms.push(self);
@@ -154,7 +154,7 @@ impl<T> std::ops::Add<Expression<T>> for Term<T> {
     }
 }
 
-impl<T> std::ops::Add<Term<T>> for Expression<T> {
+impl<T> core::ops::Add<Term<T>> for Expression<T> {
     type Output = Expression<T>;
     fn add(mut self, t: Term<T>) -> Expression<T> {
         self += t;
@@ -162,13 +162,13 @@ impl<T> std::ops::Add<Term<T>> for Expression<T> {
     }
 }
 
-impl<T> std::ops::AddAssign<Term<T>> for Expression<T> {
+impl<T> core::ops::AddAssign<Term<T>> for Expression<T> {
     fn add_assign(&mut self, t: Term<T>) {
         self.terms.push(t);
     }
 }
 
-impl<T> std::ops::Neg for Term<T> {
+impl<T> core::ops::Neg for Term<T> {
     type Output = Term<T>;
     fn neg(mut self) -> Term<T> {
         *(self.coefficient.as_mut()) = -(self.coefficient.into_inner());
@@ -176,42 +176,42 @@ impl<T> std::ops::Neg for Term<T> {
     }
 }
 
-impl<T: Clone> std::ops::Sub<f64> for Term<T> {
+impl<T: Clone> core::ops::Sub<f64> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, v: f64) -> Expression<T> {
         Expression::new(vec![self], -v)
     }
 }
 
-impl<T: Clone> std::ops::Sub<f32> for Term<T> {
+impl<T: Clone> core::ops::Sub<f32> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, v: f32) -> Expression<T> {
         self.sub(v as f64)
     }
 }
 
-impl<T: Clone> std::ops::Sub<Term<T>> for f64 {
+impl<T: Clone> core::ops::Sub<Term<T>> for f64 {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![-t], self)
     }
 }
 
-impl<T: Clone> std::ops::Sub<Term<T>> for f32 {
+impl<T: Clone> core::ops::Sub<Term<T>> for f32 {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         (self as f64).sub(t)
     }
 }
 
-impl<T: Clone> std::ops::Sub<Term<T>> for Term<T> {
+impl<T: Clone> core::ops::Sub<Term<T>> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![self, -t], 0.0)
     }
 }
 
-impl<T: Clone> std::ops::Sub<Expression<T>> for Term<T> {
+impl<T: Clone> core::ops::Sub<Expression<T>> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, mut e: Expression<T>) -> Expression<T> {
         e.negate();
@@ -220,7 +220,7 @@ impl<T: Clone> std::ops::Sub<Expression<T>> for Term<T> {
     }
 }
 
-impl<T> std::ops::Sub<Term<T>> for Expression<T> {
+impl<T> core::ops::Sub<Term<T>> for Expression<T> {
     type Output = Expression<T>;
     fn sub(mut self, t: Term<T>) -> Expression<T> {
         self -= t;
@@ -228,7 +228,7 @@ impl<T> std::ops::Sub<Term<T>> for Expression<T> {
     }
 }
 
-impl<T> std::ops::SubAssign<Term<T>> for Expression<T> {
+impl<T> core::ops::SubAssign<Term<T>> for Expression<T> {
     fn sub_assign(&mut self, t: Term<T>) {
         self.terms.push(-t);
     }
@@ -236,7 +236,7 @@ impl<T> std::ops::SubAssign<Term<T>> for Expression<T> {
 
 // Expression
 
-impl<T: Clone> std::ops::Mul<f64> for Expression<T> {
+impl<T: Clone> core::ops::Mul<f64> for Expression<T> {
     type Output = Expression<T>;
     fn mul(mut self, v: f64) -> Expression<T> {
         self *= v;
@@ -244,7 +244,7 @@ impl<T: Clone> std::ops::Mul<f64> for Expression<T> {
     }
 }
 
-impl<T: Clone> std::ops::MulAssign<f64> for Expression<T> {
+impl<T: Clone> core::ops::MulAssign<f64> for Expression<T> {
     fn mul_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) *= v;
         for t in &mut self.terms {
@@ -253,7 +253,7 @@ impl<T: Clone> std::ops::MulAssign<f64> for Expression<T> {
     }
 }
 
-impl<T: Clone> std::ops::Mul<Expression<T>> for f64 {
+impl<T: Clone> core::ops::Mul<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn mul(self, mut e: Expression<T>) -> Expression<T> {
         *(e.constant.as_mut()) *= self;
@@ -264,7 +264,7 @@ impl<T: Clone> std::ops::Mul<Expression<T>> for f64 {
     }
 }
 
-impl<T: Clone> std::ops::Div<f64> for Expression<T> {
+impl<T: Clone> core::ops::Div<f64> for Expression<T> {
     type Output = Expression<T>;
     fn div(mut self, v: f64) -> Expression<T> {
         self /= v;
@@ -272,7 +272,7 @@ impl<T: Clone> std::ops::Div<f64> for Expression<T> {
     }
 }
 
-impl<T: Clone> std::ops::DivAssign<f64> for Expression<T> {
+impl<T: Clone> core::ops::DivAssign<f64> for Expression<T> {
     fn div_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) /= v;
         for t in &mut self.terms {
@@ -281,7 +281,7 @@ impl<T: Clone> std::ops::DivAssign<f64> for Expression<T> {
     }
 }
 
-impl<T> std::ops::Add<f64> for Expression<T> {
+impl<T> core::ops::Add<f64> for Expression<T> {
     type Output = Expression<T>;
     fn add(mut self, v: f64) -> Expression<T> {
         self += v;
@@ -289,13 +289,13 @@ impl<T> std::ops::Add<f64> for Expression<T> {
     }
 }
 
-impl<T> std::ops::AddAssign<f64> for Expression<T> {
+impl<T> core::ops::AddAssign<f64> for Expression<T> {
     fn add_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) += v;
     }
 }
 
-impl<T> std::ops::Add<Expression<T>> for f64 {
+impl<T> core::ops::Add<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn add(self, mut e: Expression<T>) -> Expression<T> {
         *(e.constant.as_mut()) += self;
@@ -303,7 +303,7 @@ impl<T> std::ops::Add<Expression<T>> for f64 {
     }
 }
 
-impl<T> std::ops::Add<Expression<T>> for Expression<T> {
+impl<T> core::ops::Add<Expression<T>> for Expression<T> {
     type Output = Expression<T>;
     fn add(mut self, e: Expression<T>) -> Expression<T> {
         self += e;
@@ -311,14 +311,14 @@ impl<T> std::ops::Add<Expression<T>> for Expression<T> {
     }
 }
 
-impl<T> std::ops::AddAssign<Expression<T>> for Expression<T> {
+impl<T> core::ops::AddAssign<Expression<T>> for Expression<T> {
     fn add_assign(&mut self, mut e: Expression<T>) {
         self.terms.append(&mut e.terms);
         *(self.constant.as_mut()) += e.constant.into_inner();
     }
 }
 
-impl<T: Clone> std::ops::Neg for Expression<T> {
+impl<T: Clone> core::ops::Neg for Expression<T> {
     type Output = Expression<T>;
     fn neg(mut self) -> Expression<T> {
         self.negate();
@@ -326,7 +326,7 @@ impl<T: Clone> std::ops::Neg for Expression<T> {
     }
 }
 
-impl<T> std::ops::Sub<f64> for Expression<T> {
+impl<T> core::ops::Sub<f64> for Expression<T> {
     type Output = Expression<T>;
     fn sub(mut self, v: f64) -> Expression<T> {
         self -= v;
@@ -334,14 +334,14 @@ impl<T> std::ops::Sub<f64> for Expression<T> {
     }
 }
 
-impl<T> std::ops::SubAssign<f64> for Expression<T> {
+impl<T> core::ops::SubAssign<f64> for Expression<T> {
     fn sub_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) -= v;
     }
 }
 
 #[allow(clippy::suspicious_arithmetic_impl)]
-impl<T: Clone> std::ops::Sub<Expression<T>> for f64 {
+impl<T: Clone> core::ops::Sub<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn sub(self, mut e: Expression<T>) -> Expression<T> {
         e.negate();
@@ -350,7 +350,7 @@ impl<T: Clone> std::ops::Sub<Expression<T>> for f64 {
     }
 }
 
-impl<T: Clone> std::ops::Sub<Expression<T>> for Expression<T> {
+impl<T: Clone> core::ops::Sub<Expression<T>> for Expression<T> {
     type Output = Expression<T>;
     fn sub(mut self, e: Expression<T>) -> Expression<T> {
         self -= e;
@@ -358,7 +358,7 @@ impl<T: Clone> std::ops::Sub<Expression<T>> for Expression<T> {
     }
 }
 
-impl<T: Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
+impl<T: Clone> core::ops::SubAssign<Expression<T>> for Expression<T> {
     #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, mut e: Expression<T>) {
         e.negate();
@@ -369,14 +369,14 @@ impl<T: Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
 
 macro_rules! derive_expr_ops_for {
     ( $x:ty ) => {
-        impl<T: Clone> std::ops::Mul<$x> for Expression<T> {
+        impl<T: Clone> core::ops::Mul<$x> for Expression<T> {
             type Output = Expression<T>;
             fn mul(self, v: $x) -> Expression<T> {
                 self.mul(v as f64)
             }
         }
 
-        impl<T: Clone> std::ops::MulAssign<$x> for Expression<T> {
+        impl<T: Clone> core::ops::MulAssign<$x> for Expression<T> {
             fn mul_assign(&mut self, v: $x) {
                 let v2 = v as f64;
                 *(self.constant.as_mut()) *= v2;
@@ -386,61 +386,61 @@ macro_rules! derive_expr_ops_for {
             }
         }
 
-        impl<T: Clone> std::ops::Mul<Expression<T>> for $x {
+        impl<T: Clone> core::ops::Mul<Expression<T>> for $x {
             type Output = Expression<T>;
             fn mul(self, e: Expression<T>) -> Expression<T> {
                 (self as f64).mul(e)
             }
         }
 
-        impl<T: Clone> std::ops::Div<$x> for Expression<T> {
+        impl<T: Clone> core::ops::Div<$x> for Expression<T> {
             type Output = Expression<T>;
             fn div(self, v: $x) -> Expression<T> {
                 self.div(v as f64)
             }
         }
 
-        impl<T: Clone> std::ops::DivAssign<$x> for Expression<T> {
+        impl<T: Clone> core::ops::DivAssign<$x> for Expression<T> {
             fn div_assign(&mut self, v: $x) {
                 self.div_assign(v as f64)
             }
         }
 
-        impl<T> std::ops::Add<$x> for Expression<T> {
+        impl<T> core::ops::Add<$x> for Expression<T> {
             type Output = Expression<T>;
             fn add(self, v: $x) -> Expression<T> {
                 self.add(v as f64)
             }
         }
 
-        impl<T> std::ops::AddAssign<$x> for Expression<T> {
+        impl<T> core::ops::AddAssign<$x> for Expression<T> {
             fn add_assign(&mut self, v: $x) {
                 self.add_assign(v as f64)
             }
         }
 
-        impl<T> std::ops::Add<Expression<T>> for $x {
+        impl<T> core::ops::Add<Expression<T>> for $x {
             type Output = Expression<T>;
             fn add(self, e: Expression<T>) -> Expression<T> {
                 (self as f64).add(e)
             }
         }
 
-        impl<T> std::ops::Sub<$x> for Expression<T> {
+        impl<T> core::ops::Sub<$x> for Expression<T> {
             type Output = Expression<T>;
             fn sub(self, v: $x) -> Expression<T> {
                 self.sub(v as f64)
             }
         }
 
-        impl<T: Clone> std::ops::Sub<Expression<T>> for $x {
+        impl<T: Clone> core::ops::Sub<Expression<T>> for $x {
             type Output = Expression<T>;
             fn sub(self, e: Expression<T>) -> Expression<T> {
                 (self as f64).sub(e)
             }
         }
 
-        impl<T> std::ops::SubAssign<$x> for Expression<T> {
+        impl<T> core::ops::SubAssign<$x> for Expression<T> {
             fn sub_assign(&mut self, v: $x) {
                 self.sub_assign(v as f64)
             }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,34 +1,44 @@
-use crate::{
-    Term,
-    Expression,
-    Constraint
-};
+use crate::{Constraint, Expression, Term};
 
 /// A trait for creating constraints using custom variable types.
 pub trait Constrainable<Var>
 where
     Var: Sized,
-    Self: Sized
+    Self: Sized,
 {
-    fn equal_to<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone;
+    fn equal_to<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone;
 
-    fn is<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone {
+    fn is<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone,
+    {
         self.equal_to(x)
     }
 
-    fn greater_than_or_equal_to<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone;
+    fn greater_than_or_equal_to<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone;
 
-    fn is_ge<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone {
+    fn is_ge<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone,
+    {
         self.greater_than_or_equal_to(x)
     }
 
-    fn less_than_or_equal_to<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone;
+    fn less_than_or_equal_to<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone;
 
-    fn is_le<X>(self, x: X) -> Constraint<Var> where X: Into<Expression<Var>> + Clone {
+    fn is_le<X>(self, x: X) -> Constraint<Var>
+    where
+        X: Into<Expression<Var>> + Clone,
+    {
         self.less_than_or_equal_to(x)
     }
 }
-
 
 // Term
 
@@ -101,35 +111,35 @@ impl<T> std::ops::DivAssign<f32> for Term<T> {
     }
 }
 
-impl<T:Clone> std::ops::Add<f64> for Term<T> {
+impl<T: Clone> std::ops::Add<f64> for Term<T> {
     type Output = Expression<T>;
     fn add(self, v: f64) -> Expression<T> {
         Expression::new(vec![self], v)
     }
 }
 
-impl<T:Clone> std::ops::Add<f32> for Term<T> {
+impl<T: Clone> std::ops::Add<f32> for Term<T> {
     type Output = Expression<T>;
     fn add(self, v: f32) -> Expression<T> {
         self.add(v as f64)
     }
 }
 
-impl<T:Clone> std::ops::Add<Term<T>> for f64 {
+impl<T: Clone> std::ops::Add<Term<T>> for f64 {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![t], self)
     }
 }
 
-impl<T:Clone> std::ops::Add<Term<T>> for f32 {
+impl<T: Clone> std::ops::Add<Term<T>> for f32 {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         (self as f64).add(t)
     }
 }
 
-impl<T:Clone> std::ops::Add<Term<T>> for Term<T> {
+impl<T: Clone> std::ops::Add<Term<T>> for Term<T> {
     type Output = Expression<T>;
     fn add(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![self, t], 0.0)
@@ -166,42 +176,42 @@ impl<T> std::ops::Neg for Term<T> {
     }
 }
 
-impl<T:Clone> std::ops::Sub<f64> for Term<T> {
+impl<T: Clone> std::ops::Sub<f64> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, v: f64) -> Expression<T> {
         Expression::new(vec![self], -v)
     }
 }
 
-impl<T:Clone> std::ops::Sub<f32> for Term<T> {
+impl<T: Clone> std::ops::Sub<f32> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, v: f32) -> Expression<T> {
         self.sub(v as f64)
     }
 }
 
-impl<T:Clone> std::ops::Sub<Term<T>> for f64 {
+impl<T: Clone> std::ops::Sub<Term<T>> for f64 {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![-t], self)
     }
 }
 
-impl<T:Clone> std::ops::Sub<Term<T>> for f32 {
+impl<T: Clone> std::ops::Sub<Term<T>> for f32 {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         (self as f64).sub(t)
     }
 }
 
-impl<T:Clone> std::ops::Sub<Term<T>> for Term<T> {
+impl<T: Clone> std::ops::Sub<Term<T>> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, t: Term<T>) -> Expression<T> {
         Expression::new(vec![self, -t], 0.0)
     }
 }
 
-impl<T:Clone> std::ops::Sub<Expression<T>> for Term<T> {
+impl<T: Clone> std::ops::Sub<Expression<T>> for Term<T> {
     type Output = Expression<T>;
     fn sub(self, mut e: Expression<T>) -> Expression<T> {
         e.negate();
@@ -226,7 +236,7 @@ impl<T> std::ops::SubAssign<Term<T>> for Expression<T> {
 
 // Expression
 
-impl<T:Clone> std::ops::Mul<f64> for Expression<T> {
+impl<T: Clone> std::ops::Mul<f64> for Expression<T> {
     type Output = Expression<T>;
     fn mul(mut self, v: f64) -> Expression<T> {
         self *= v.clone();
@@ -234,7 +244,7 @@ impl<T:Clone> std::ops::Mul<f64> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::MulAssign<f64> for Expression<T> {
+impl<T: Clone> std::ops::MulAssign<f64> for Expression<T> {
     fn mul_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) *= v;
         for t in &mut self.terms {
@@ -243,7 +253,7 @@ impl<T:Clone> std::ops::MulAssign<f64> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::Mul<Expression<T>> for f64 {
+impl<T: Clone> std::ops::Mul<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn mul(self, mut e: Expression<T>) -> Expression<T> {
         *(e.constant.as_mut()) *= self;
@@ -254,7 +264,7 @@ impl<T:Clone> std::ops::Mul<Expression<T>> for f64 {
     }
 }
 
-impl<T:Clone> std::ops::Div<f64> for Expression<T> {
+impl<T: Clone> std::ops::Div<f64> for Expression<T> {
     type Output = Expression<T>;
     fn div(mut self, v: f64) -> Expression<T> {
         self /= v;
@@ -262,7 +272,7 @@ impl<T:Clone> std::ops::Div<f64> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::DivAssign<f64> for Expression<T> {
+impl<T: Clone> std::ops::DivAssign<f64> for Expression<T> {
     fn div_assign(&mut self, v: f64) {
         *(self.constant.as_mut()) /= v;
         for t in &mut self.terms {
@@ -308,7 +318,7 @@ impl<T> std::ops::AddAssign<Expression<T>> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::Neg for Expression<T> {
+impl<T: Clone> std::ops::Neg for Expression<T> {
     type Output = Expression<T>;
     fn neg(mut self) -> Expression<T> {
         self.negate();
@@ -330,7 +340,7 @@ impl<T> std::ops::SubAssign<f64> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::Sub<Expression<T>> for f64 {
+impl<T: Clone> std::ops::Sub<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn sub(self, mut e: Expression<T>) -> Expression<T> {
         e.negate();
@@ -339,7 +349,7 @@ impl<T:Clone> std::ops::Sub<Expression<T>> for f64 {
     }
 }
 
-impl<T:Clone> std::ops::Sub<Expression<T>> for Expression<T> {
+impl<T: Clone> std::ops::Sub<Expression<T>> for Expression<T> {
     type Output = Expression<T>;
     fn sub(mut self, e: Expression<T>) -> Expression<T> {
         self -= e;
@@ -347,7 +357,7 @@ impl<T:Clone> std::ops::Sub<Expression<T>> for Expression<T> {
     }
 }
 
-impl<T:Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
+impl<T: Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
     fn sub_assign(&mut self, mut e: Expression<T>) {
         e.negate();
         self.terms.append(&mut e.terms);
@@ -356,84 +366,84 @@ impl<T:Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
 }
 
 macro_rules! derive_expr_ops_for {
-  ( $x:ty ) => {
-    impl<T:Clone> std::ops::Mul<$x> for Expression<T> {
-      type Output = Expression<T>;
-      fn mul(self, v: $x) -> Expression<T> {
-        self.mul(v as f64)
-      }
-    }
-
-    impl<T:Clone> std::ops::MulAssign<$x> for Expression<T> {
-      fn mul_assign(&mut self, v: $x) {
-        let v2 = v as f64;
-        *(self.constant.as_mut()) *= v2;
-        for t in &mut self.terms {
-          *t = t.clone() * v2;
+    ( $x:ty ) => {
+        impl<T: Clone> std::ops::Mul<$x> for Expression<T> {
+            type Output = Expression<T>;
+            fn mul(self, v: $x) -> Expression<T> {
+                self.mul(v as f64)
+            }
         }
-      }
-    }
 
-    impl<T:Clone> std::ops::Mul<Expression<T>> for $x {
-      type Output = Expression<T>;
-      fn mul(self, e: Expression<T>) -> Expression<T> {
-        (self as f64).mul(e)
-      }
-    }
+        impl<T: Clone> std::ops::MulAssign<$x> for Expression<T> {
+            fn mul_assign(&mut self, v: $x) {
+                let v2 = v as f64;
+                *(self.constant.as_mut()) *= v2;
+                for t in &mut self.terms {
+                    *t = t.clone() * v2;
+                }
+            }
+        }
 
-    impl<T:Clone> std::ops::Div<$x> for Expression<T> {
-      type Output = Expression<T>;
-      fn div(self, v: $x) -> Expression<T> {
-        self.div(v as f64)
-      }
-    }
+        impl<T: Clone> std::ops::Mul<Expression<T>> for $x {
+            type Output = Expression<T>;
+            fn mul(self, e: Expression<T>) -> Expression<T> {
+                (self as f64).mul(e)
+            }
+        }
 
-    impl<T:Clone> std::ops::DivAssign<$x> for Expression<T> {
-      fn div_assign(&mut self, v: $x) {
-        self.div_assign(v as f64)
-      }
-    }
+        impl<T: Clone> std::ops::Div<$x> for Expression<T> {
+            type Output = Expression<T>;
+            fn div(self, v: $x) -> Expression<T> {
+                self.div(v as f64)
+            }
+        }
 
-    impl<T> std::ops::Add<$x> for Expression<T> {
-      type Output = Expression<T>;
-      fn add(self, v: $x) -> Expression<T> {
-        self.add(v as f64)
-      }
-    }
+        impl<T: Clone> std::ops::DivAssign<$x> for Expression<T> {
+            fn div_assign(&mut self, v: $x) {
+                self.div_assign(v as f64)
+            }
+        }
 
-    impl<T> std::ops::AddAssign<$x> for Expression<T> {
-      fn add_assign(&mut self, v: $x) {
-        self.add_assign(v as f64)
-      }
-    }
+        impl<T> std::ops::Add<$x> for Expression<T> {
+            type Output = Expression<T>;
+            fn add(self, v: $x) -> Expression<T> {
+                self.add(v as f64)
+            }
+        }
 
-    impl<T> std::ops::Add<Expression<T>> for $x {
-      type Output = Expression<T>;
-      fn add(self, e: Expression<T>) -> Expression<T> {
-        (self as f64).add(e)
-      }
-    }
+        impl<T> std::ops::AddAssign<$x> for Expression<T> {
+            fn add_assign(&mut self, v: $x) {
+                self.add_assign(v as f64)
+            }
+        }
 
-    impl<T> std::ops::Sub<$x> for Expression<T> {
-      type Output = Expression<T>;
-      fn sub(self, v: $x) -> Expression<T> {
-        self.sub(v as f64)
-      }
-    }
+        impl<T> std::ops::Add<Expression<T>> for $x {
+            type Output = Expression<T>;
+            fn add(self, e: Expression<T>) -> Expression<T> {
+                (self as f64).add(e)
+            }
+        }
 
-    impl<T:Clone> std::ops::Sub<Expression<T>> for $x {
-      type Output = Expression<T>;
-      fn sub(self, e: Expression<T>) -> Expression<T> {
-        (self as f64).sub(e)
-      }
-    }
+        impl<T> std::ops::Sub<$x> for Expression<T> {
+            type Output = Expression<T>;
+            fn sub(self, v: $x) -> Expression<T> {
+                self.sub(v as f64)
+            }
+        }
 
-    impl<T> std::ops::SubAssign<$x> for Expression<T> {
-      fn sub_assign(&mut self, v: $x) {
-        self.sub_assign(v as f64)
-      }
-    }
-  };
+        impl<T: Clone> std::ops::Sub<Expression<T>> for $x {
+            type Output = Expression<T>;
+            fn sub(self, e: Expression<T>) -> Expression<T> {
+                (self as f64).sub(e)
+            }
+        }
+
+        impl<T> std::ops::SubAssign<$x> for Expression<T> {
+            fn sub_assign(&mut self, v: $x) {
+                self.sub_assign(v as f64)
+            }
+        }
+    };
 }
 
 derive_expr_ops_for!(f32);

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -239,7 +239,7 @@ impl<T> std::ops::SubAssign<Term<T>> for Expression<T> {
 impl<T: Clone> std::ops::Mul<f64> for Expression<T> {
     type Output = Expression<T>;
     fn mul(mut self, v: f64) -> Expression<T> {
-        self *= v.clone();
+        self *= v;
         self
     }
 }
@@ -340,6 +340,7 @@ impl<T> std::ops::SubAssign<f64> for Expression<T> {
     }
 }
 
+#[allow(clippy::suspicious_arithmetic_impl)]
 impl<T: Clone> std::ops::Sub<Expression<T>> for f64 {
     type Output = Expression<T>;
     fn sub(self, mut e: Expression<T>) -> Expression<T> {
@@ -358,6 +359,7 @@ impl<T: Clone> std::ops::Sub<Expression<T>> for Expression<T> {
 }
 
 impl<T: Clone> std::ops::SubAssign<Expression<T>> for Expression<T> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, mut e: Expression<T>) {
         e.negate();
         self.terms.append(&mut e.terms);

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -4,12 +4,7 @@ use crate::{
     SuggestValueError, Symbol, SymbolType, Tag, Term,
 };
 
-use std::{
-    any::Any,
-    collections::hash_map::Entry,
-    fmt::Debug,
-    hash::Hash,
-};
+use std::{any::Any, collections::hash_map::Entry, fmt::Debug, hash::Hash};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -1,12 +1,14 @@
 use crate::{
+    hash_map::{Entry, FxHashMap, FxHashSet},
     near_zero, strength, AddConstraintError, AddEditVariableError, Constraint, Expression,
     InternalSolverError, RelationalOperator, RemoveConstraintError, RemoveEditVariableError, Row,
     SuggestValueError, Symbol, SymbolType, Tag, Term,
 };
 
-use std::{any::Any, collections::hash_map::Entry, fmt::Debug, hash::Hash};
+use core::{any::Any, fmt::Debug, hash::Hash};
 
-use rustc_hash::{FxHashMap, FxHashSet};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 #[derive(Clone, Debug)]
 struct EditInfo<T> {


### PR DESCRIPTION
Cargo can not enable (https://github.com/rust-lang/cargo/issues/1839) optional dependencies if a feature is disabled so I have to add another feature `hashbrown` to make the dependency optional. User should enable `hashbrown` feature if `std` feature is disabled. It's sad that it can not be done by cargo right now.